### PR TITLE
fix: stabilize darwin rebuild, brew env, and prompt timeouts

### DIFF
--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -5,7 +5,8 @@ _: {
   };
 
   targets.darwin.copyApps.enable = false;
-  targets.darwin.linkApps.enable = false;
+  # Keep copies disabled to avoid drift, but expose GUI apps via symlinks.
+  targets.darwin.linkApps.enable = true;
 
   # Marked broken Oct 20, 2022 check later to remove this
   # https://github.com/nix-community/home-manager/issues/3344

--- a/modules/home-manager/starship.nix
+++ b/modules/home-manager/starship.nix
@@ -3,6 +3,7 @@ _: {
     enable = true;
     enableZshIntegration = true;
     settings = {
+      command_timeout = 2000;
       battery.disabled = true;
     };
   };

--- a/modules/home-manager/zsh/aliases.nix
+++ b/modules/home-manager/zsh/aliases.nix
@@ -74,9 +74,15 @@
     nixcleanup = "nix-env --delete-generations +2 && nix store gc && nix-channel --update && nix-env -u --always && nix-collect-garbage -d && sudo /run/current-system/bin/switch-to-configuration switch";
   };
   darwin = {
-    nixrebuild = "f() { git -C $BLAZINGLY_FAST add . && sudo darwin-rebuild switch --flake $BLAZINGLY_FAST --impure $1 }; f";
+    # nix-darwin invocation that works even when darwin-rebuild is not in PATH.
+    brew = "env -u DEVELOPER_DIR -u SDKROOT brew";
+    drs = "env -u DEVELOPER_DIR -u SDKROOT sudo nix --extra-experimental-features \"nix-command flakes\" run nix-darwin -- switch --flake $BLAZINGLY_FAST#Pro";
+    drb = "env -u DEVELOPER_DIR -u SDKROOT nix --extra-experimental-features \"nix-command flakes\" run nix-darwin -- build --flake $BLAZINGLY_FAST#Pro";
+    darwin-switch = "env -u DEVELOPER_DIR -u SDKROOT sudo nix --extra-experimental-features \"nix-command flakes\" run nix-darwin -- switch --flake $BLAZINGLY_FAST#Pro";
+    darwin-build = "env -u DEVELOPER_DIR -u SDKROOT nix --extra-experimental-features \"nix-command flakes\" run nix-darwin -- build --flake $BLAZINGLY_FAST#Pro";
+    nixrebuild = "f() { git -C $BLAZINGLY_FAST add . && env -u DEVELOPER_DIR -u SDKROOT sudo nix --extra-experimental-features \"nix-command flakes\" run nix-darwin -- switch --flake $BLAZINGLY_FAST#Pro --impure \"$@\"; }; f";
     nbdry = "f() { cd $BLAZINGLY_FAST && ./scripts/darwin-pro build --dry-run --show-trace -v \"$@\" && cd -}; f || cd -";
-    nsdry = "f() { cd $BLAZINGLY_FAST && sudo darwin-rebuild switch --flake $BLAZINGLY_FAST#Pro --dry-run \"$@\" && cd -}; f || cd -";
+    nsdry = "f() { cd $BLAZINGLY_FAST && env -u DEVELOPER_DIR -u SDKROOT sudo nix --extra-experimental-features \"nix-command flakes\" run nix-darwin -- switch --flake $BLAZINGLY_FAST#Pro --dry-run \"$@\" && cd -}; f || cd -";
   };
 in
   lib.mkMerge [

--- a/scripts/darwin-pro
+++ b/scripts/darwin-pro
@@ -14,16 +14,22 @@ cmd="${1:-}"
 case "$cmd" in
   build)
     shift
-    exec darwin-rebuild build --flake "$flake_target" "$@"
+    exec env -u DEVELOPER_DIR -u SDKROOT \
+      nix --extra-experimental-features "nix-command flakes" \
+      run nix-darwin -- build --flake "$flake_target" "$@"
     ;;
   switch)
     shift
-    exec sudo darwin-rebuild switch --flake "$flake_target" "$@"
+    exec env -u DEVELOPER_DIR -u SDKROOT \
+      sudo nix --extra-experimental-features "nix-command flakes" \
+      run nix-darwin -- switch --flake "$flake_target" "$@"
     ;;
   rollback)
     shift
     # Rollback is generation-based; flake selection does not apply.
-    exec sudo darwin-rebuild switch --rollback "$@"
+    exec env -u DEVELOPER_DIR -u SDKROOT \
+      sudo nix --extra-experimental-features "nix-command flakes" \
+      run nix-darwin -- switch --rollback "$@"
     ;;
   edit)
     shift


### PR DESCRIPTION
## Summary
- enable Home Manager Darwin app linking () so GUI apps like Alacritty are exposed properly
- add Starship  to avoid node version timeout warnings
- update Darwin aliases to use  and add short aliases (, )
- ensure brew and nix-darwin commands run with / unset to avoid CLT/Swift mismatch inside nix-direnv shells
- migrate  away from  binary dependency

## Validation
-  confirms alias and Home Manager target changes
- 
- verified  and  install successfully with clean env
