### PR TITLE
fix(ci): gate Home Manager darwin linkApps to darwin hosts

### DIFF
--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -1,14 +1,23 @@
-_: {
-  home = {
-    enableNixpkgsReleaseCheck = false;
-    stateVersion = "25.11";
-  };
+{
+  lib,
+  pkgs,
+  ...
+}:
+lib.mkMerge [
+  {
+    home = {
+      enableNixpkgsReleaseCheck = false;
+      stateVersion = "25.11";
+    };
 
-  targets.darwin.copyApps.enable = false;
-  # Keep copies disabled to avoid drift, but expose GUI apps via symlinks.
-  targets.darwin.linkApps.enable = true;
+    # Marked broken Oct 20, 2022 check later to remove this
+    # https://github.com/nix-community/home-manager/issues/3344
+    # manual.manpages.enable = false;
+  }
 
-  # Marked broken Oct 20, 2022 check later to remove this
-  # https://github.com/nix-community/home-manager/issues/3344
-  # manual.manpages.enable = false;
-}
+  (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+    targets.darwin.copyApps.enable = false;
+    # Keep copies disabled to avoid drift, but expose GUI apps via symlinks.
+    targets.darwin.linkApps.enable = true;
+  })
+]


### PR DESCRIPTION
## Problem
CI was evaluating the admin Home Manager profile on non-Darwin targets and hitting:

- 

## Fix
- Updated  to gate Darwin-only settings behind 
- Kept existing  behavior unchanged for Darwin hosts

## Why this works
 options are now only set on Darwin systems, so Linux/NixOS CI evaluations no longer attempt to load unsupported Darwin target options.
