### PR TITLE
nix: declarative language toolchain + release-aligned darwin inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,16 +168,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1765980955,
-        "narHash": "sha256-rB45jv4uwC90vM9UZ70plfvY/2Kdygs+zlQ07dGQFk4=",
+        "lastModified": 1772302941,
+        "narHash": "sha256-TL3+ckbOTILXrR0qSK3dJj2BJ0S5yz/YSsUF1oEgd9g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "89c9508bbe9b40d36b3dc206c2483ef176f15173",
+        "rev": "9b9142b5fe214c2adabe86257c33e022372b7c96",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "master",
+        "ref": "release-25.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -210,16 +210,18 @@
         ]
       },
       "locked": {
-        "lastModified": 1764161084,
-        "narHash": "sha256-HN84sByg9FhJnojkGGDSrcjcbeioFWoNXfuyYfJ1kBE=",
-        "rev": "e95de00a471d07435e0527ff4db092c84998698e",
-        "revCount": 2287,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-darwin/nix-darwin/0.1.2287%2Brev-e95de00a471d07435e0527ff4db092c84998698e/019ac043-24d1-7661-b491-7fcf15342265/source.tar.gz"
+        "lastModified": 1772129556,
+        "narHash": "sha256-Utk0zd8STPsUJPyjabhzPc5BpPodLTXrwkpXBHYnpeg=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "ebec37af18215214173c98cf6356d0aca24a2585",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/nix-darwin/nix-darwin/0.1"
+        "owner": "nix-darwin",
+        "ref": "nix-darwin-25.11",
+        "repo": "nix-darwin",
+        "type": "github"
       }
     },
     "nixos-hardware": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
     nixpkgs-unstable.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
     nix-darwin = {
-      url = "https://flakehub.com/f/nix-darwin/nix-darwin/0.1";
+      url = "github:nix-darwin/nix-darwin/nix-darwin-25.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     determinate = {
@@ -14,7 +14,7 @@
     };
     nixos-hardware.url = "github:nixos/nixos-hardware/master";
     home-manager = {
-      url = "github:nix-community/home-manager/master";
+      url = "github:nix-community/home-manager/release-25.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flake-utils.url = "github:numtide/flake-utils";

--- a/hosts/darwin/Pro/languages.nix
+++ b/hosts/darwin/Pro/languages.nix
@@ -1,6 +1,23 @@
 {pkgs, ...}: {
   environment.systemPackages = with pkgs; [
+    # JavaScript/TypeScript runtimes and package managers
     nodejs_20
     pnpm_10
+    bun
+    deno
+    fnm
+
+    # Rust toolchain
+    rustc
+    cargo
+    clippy
+    rustfmt
+    rust-analyzer
+
+    # Haskell toolchain
+    ghc
+    cabal-install
+    haskell-language-server
+    stack
   ];
 }

--- a/modules/home-manager/zsh/default.nix
+++ b/modules/home-manager/zsh/default.nix
@@ -44,6 +44,11 @@
         *) export PATH="$PNPM_HOME:$PATH" ;;
       esac
 
+      # fnm setup (Nix-native alternative to nvm)
+      if command -v fnm >/dev/null 2>&1; then
+        eval "$(fnm env --use-on-cd --shell zsh)"
+      fi
+
       if [ -f "$HOME/.zshrc_custom" ]; then
         source "$HOME/.zshrc_custom"
       fi


### PR DESCRIPTION
Summary
- pin nix-darwin to nix-darwin-25.11 and home-manager to release-25.11 to match nixpkgs
- extend Darwin language packages with Bun, Deno, Rust toolchain, Haskell toolchain, and fnm
- add zsh init for fnm automatic environment loading
- refresh flake.lock for updated inputs

Why
This fixes nix-darwin release mismatch errors after input updates while keeping language/runtime tooling declarative.

Validation
- nix build .#checks.aarch64-darwin.darwin-pro --no-link --dry-run