### PR TITLE
fix(ghostty): explicit shell to avoid --posix

### DIFF
--- a/modules/home-manager/ghostty.nix
+++ b/modules/home-manager/ghostty.nix
@@ -10,6 +10,7 @@
       then "14"
       else "10";
   in ''
+    command = /bin/zsh -l
     font-family = JetBrainsMono Nerd Font
     font-size = ${fontSize}
     cursor-style = block


### PR DESCRIPTION
## Summary
- Add `command = /bin/zsh -l` to ghostty config
- Fixes: Ghostty launching zsh with `--posix` flag which zsh doesn't support

## Test plan
- [x] `nix flake check` passes
- [ ] Ghostty opens with working zsh shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)