### PR TITLE
Fix zoxide double-init, go/docker collision, dead code

### DIFF
--- a/build-pro.sh
+++ b/build-pro.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Kechroq ishga tushirish uchun: Pro (darwin) hostni build+switch qilish.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "== nix build (darwin toplevel) =="
+nix build --no-update-lock-file --no-link .#darwinConfigurations.pro.config.system.build.toplevel
+
+echo "== darwin-rebuild switch =="
+sudo darwin-rebuild switch --flake .#pro

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,6 @@
 {
   description = "blazingly fast nix config";
   inputs = {
-    # nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
     nixpkgs-unstable.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
     nix-darwin = {

--- a/hosts/darwin/Pro/languages.nix
+++ b/hosts/darwin/Pro/languages.nix
@@ -5,8 +5,8 @@
     nodejs
     pnpm
     bun
-    deno
-    go
+    unstable.deno
+    unstable.go
     codex
     fnm
     autojump

--- a/modules/home-manager/neovim.nix
+++ b/modules/home-manager/neovim.nix
@@ -29,7 +29,7 @@ let
     nodePackages.yaml-language-server
 
     # Containers
-    docker
+    docker_29
     docker-compose
     dockerfile-language-server
 

--- a/modules/home-manager/yazi.nix
+++ b/modules/home-manager/yazi.nix
@@ -1,7 +1,11 @@
 {pkgs, ...}: {
   programs.zoxide = {
     enable = true;
-    enableZshIntegration = true;
+    # HM's zsh integration inits too early (before mkAfter content/plugins),
+    # so chpwd_functions ends up with zoxide's hook non-last -> _ZO_DOCTOR
+    # warning (nix-community/home-manager#9349). Real init happens at the
+    # end of modules/home-manager/zsh/default.nix instead.
+    enableZshIntegration = false;
     options = ["--cmd" "cd"];
   };
 

--- a/modules/home-manager/zsh/default.nix
+++ b/modules/home-manager/zsh/default.nix
@@ -74,7 +74,9 @@
           source "$HOME/.zshrc_custom"
         fi
 
-        # Fallback init in case HM zoxide integration isn't loaded yet.
+        # HM's built-in zsh integration is disabled (programs.zoxide.enableZshIntegration = false
+        # in yazi.nix) because it inits too early and trips the _ZO_DOCTOR warning; init here instead,
+        # at the true end of initContent.
         if command -v zoxide >/dev/null 2>&1; then
           eval "$(zoxide init zsh --cmd cd)"
         fi

--- a/modules/packages/linux.nix
+++ b/modules/packages/linux.nix
@@ -9,7 +9,6 @@ with pkgs; [
   pinentry-all
   android-studio
   google-chrome
-  element-desktop
   xclip
   wl-clipboard
   wpsoffice
@@ -17,4 +16,5 @@ with pkgs; [
   guvcview
   postman
   vlc
+  go
 ]

--- a/modules/packages/shared.nix
+++ b/modules/packages/shared.nix
@@ -37,7 +37,7 @@ with pkgs;
   bundletool
 
   # Cloud-related tools and SDKs
-  docker
+  docker_29
   docker-compose
   google-cloud-sdk
 
@@ -49,7 +49,6 @@ with pkgs;
   nodePackages.jsdoc
   nodejs
   pnpm
-  go
 
   # Text and terminal utilities
   htop


### PR DESCRIPTION
## Summary
- zoxide: disable HM's early zsh integration (`yazi.nix`) — it loaded before mkAfter/plugins and tripped the `_ZO_DOCTOR` warning on every shell (nix-community/home-manager#9349). Kept single correctly-placed init at end of `zsh/default.nix`.
- go/deno on Pro moved to `unstable` (`languages.nix`); removed now-duplicate stable `go` from `shared.nix` (was colliding with `unstable.go` — profile build failure on darwin), re-added `go` to `linux.nix` for dreampad.
- `linux.nix`: dedup `element-desktop`.
- `flake.nix`: drop dead commented `nixpkgs.url` line.
- `docker` -> `docker_29` pin (neovim.nix, shared.nix).
- Added `build-pro.sh` for manual build+switch later.

## Test plan
- [x] `nix-instantiate --parse` on all touched files
- [x] `nix eval .#darwinConfigurations.pro.config.environment.systemPackages` — no collision, evals clean
- [x] Rendered actual `.zshrc` via `nix eval`, sourced it in a real zsh session, confirmed `__zoxide_hook` is last in `chpwd_functions` and no `_ZO_DOCTOR` warning fires on `cd`
- [ ] `sudo darwin-rebuild switch` on the actual Pro machine